### PR TITLE
Scoop manifest update for auth0-cli version v1.6.1

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.6.0",
+    "version": "1.6.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.6.0/auth0-cli_1.6.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.6.1/auth0-cli_1.6.1_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "6b97df8d8999567872f2efef9416ea0e3d368a0e0b1532ff3f46fffc5b25a942"
+            "hash": "3e1b089b671b5c6fe258c8e23f7b468e5d03fd82c50df0acf976e681cf9a85a9"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.6.0/auth0-cli_1.6.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.6.1/auth0-cli_1.6.1_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "80635fb2182d2c1daf19541a6d9bd8429c8264d11c64d3f435ccfdf35d37f96e"
+            "hash": "69664595de983f1e36939f52e3e29a61b333d21d2792cbbcd28af4a3d7d88d49"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
### Description
This is normally done automatically but our automated release pipeline is incurring issues today.