### PR TITLE
Scoop manifest update for auth0-cli version v1.10.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.9.3",
+    "version": "1.10.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.9.3/auth0-cli_1.9.3_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.10.0/auth0-cli_1.10.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "31fe3bca3bdd7a310e25f7b3d7845cecf2f4c3c7986eaab75590c8966efa2399"
+            "hash": "4bbf4e7f500a7934c4b0d652cf517bdd1dc53b5bfee05875d1357524b7166a84"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.9.3/auth0-cli_1.9.3_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.10.0/auth0-cli_1.10.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "e79c44e9ac9a379c9f2a2a72f0bf96fb8d3f53f44dbdd3dc68235609c2dd3c5d"
+            "hash": "9988bf5dd394b767d829a08c1ed1956d121a554fff86c4d1bc47eb9d52a88c7f"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.10.0.