### PR TITLE
Scoop manifest update for auth0-cli version v1.11.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.10.1",
+    "version": "1.11.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.10.1/auth0-cli_1.10.1_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.11.0/auth0-cli_1.11.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "359a6042c250351762f5077ef818384e4557583b780193109838d89e10e253e4"
+            "hash": "a87a6017316b94be37958524c1f655888d8f4a4459ac53ed295d2172cd71962e"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.10.1/auth0-cli_1.10.1_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.11.0/auth0-cli_1.11.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "fdcc10fcf1e54a4cdf6a4e519b630651bd665b6e69f7d7dc56e6d9e97b0ba4a6"
+            "hash": "7c5fb8b89b3544f2f994d8c064f0c731b4c946a58993e29254d64aff565f4e41"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.11.0.