### PR TITLE
Scoop manifest update for auth0-cli version v1.12.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.11.0",
+    "version": "1.12.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.11.0/auth0-cli_1.11.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.12.0/auth0-cli_1.12.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "a87a6017316b94be37958524c1f655888d8f4a4459ac53ed295d2172cd71962e"
+            "hash": "19310b5b4eb20118db2ea39f17d95a966f6eb0ada42252770c3da8a82642ec03"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.11.0/auth0-cli_1.11.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.12.0/auth0-cli_1.12.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "7c5fb8b89b3544f2f994d8c064f0c731b4c946a58993e29254d64aff565f4e41"
+            "hash": "9d86672a58580e8c91af962ccd5bb6362a70b339177098479e85e0a436eb1b0c"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.12.0.