### PR TITLE
Scoop manifest update for auth0-cli version v1.13.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.12.0",
+    "version": "1.13.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.12.0/auth0-cli_1.12.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.13.0/auth0-cli_1.13.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "19310b5b4eb20118db2ea39f17d95a966f6eb0ada42252770c3da8a82642ec03"
+            "hash": "06ec88ec176ef620e9f01c761af7013ec4a47820acb93eda69bf4ff135e36523"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.12.0/auth0-cli_1.12.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.13.0/auth0-cli_1.13.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "9d86672a58580e8c91af962ccd5bb6362a70b339177098479e85e0a436eb1b0c"
+            "hash": "76e160fa72f420a0859feb3a5e4464afa85db7bbda7163b9b2392d594fff9ec3"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.13.0.