### PR TITLE
Scoop manifest update for auth0-cli version v1.14.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.13.0",
+    "version": "1.14.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.13.0/auth0-cli_1.13.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.0/auth0-cli_1.14.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "06ec88ec176ef620e9f01c761af7013ec4a47820acb93eda69bf4ff135e36523"
+            "hash": "7249fff5784768d8e5cda0b3ed361e57eab924005ea4798ec34a7100725d5ee2"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.13.0/auth0-cli_1.13.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.0/auth0-cli_1.14.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "76e160fa72f420a0859feb3a5e4464afa85db7bbda7163b9b2392d594fff9ec3"
+            "hash": "da16ce309cb7480b48eea6dd9638fb626227d8b3304599b515a2d794e7b77179"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.14.0.