### PR TITLE
Scoop manifest update for auth0-cli version v1.14.1

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.14.0",
+    "version": "1.14.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.0/auth0-cli_1.14.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.1/auth0-cli_1.14.1_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "7249fff5784768d8e5cda0b3ed361e57eab924005ea4798ec34a7100725d5ee2"
+            "hash": "c877278915186a289721f9ae6a1c7271e286ab547eb0bee4b121d29141172e0e"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.0/auth0-cli_1.14.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.1/auth0-cli_1.14.1_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "da16ce309cb7480b48eea6dd9638fb626227d8b3304599b515a2d794e7b77179"
+            "hash": "5d3ad49bbdb195904c39319b96e8cd50fe7bd8e17823a7b2441cba745034d83b"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.14.1.