### PR TITLE
Scoop manifest update for auth0-cli version v1.15.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.14.1",
+    "version": "1.15.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.1/auth0-cli_1.14.1_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.15.0/auth0-cli_1.15.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "c877278915186a289721f9ae6a1c7271e286ab547eb0bee4b121d29141172e0e"
+            "hash": "9a93ffb022f8184ddfc8446d79f5c1705ad4911e2b9379986cf57f24a05152e0"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.14.1/auth0-cli_1.14.1_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.15.0/auth0-cli_1.15.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "5d3ad49bbdb195904c39319b96e8cd50fe7bd8e17823a7b2441cba745034d83b"
+            "hash": "11d34fb67059691c1ada4f974ea6b6883e878053e3420d5da1a6747387ab02cd"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.15.0.