### PR TITLE
Scoop manifest update for auth0-cli version v1.16.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.15.0",
+    "version": "1.16.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.15.0/auth0-cli_1.15.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.16.0/auth0-cli_1.16.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "9a93ffb022f8184ddfc8446d79f5c1705ad4911e2b9379986cf57f24a05152e0"
+            "hash": "a404bd9e7e4df590185c89d50693349d8e473fa1b546a8e1cedc9affaefec95e"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.15.0/auth0-cli_1.15.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.16.0/auth0-cli_1.16.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "11d34fb67059691c1ada4f974ea6b6883e878053e3420d5da1a6747387ab02cd"
+            "hash": "50206066f01f4a9d9151e028034ab46375f44fab39bfb459f91eb4a07c77e8da"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.16.0.