### PR TITLE
Scoop manifest update for auth0-cli version v1.17.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.16.0",
+    "version": "1.17.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.16.0/auth0-cli_1.16.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "a404bd9e7e4df590185c89d50693349d8e473fa1b546a8e1cedc9affaefec95e"
+            "hash": "a843e40381e805b97cfb98b09f6c7400dd993811024040b7a1d35538bf7efde7"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.16.0/auth0-cli_1.16.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "50206066f01f4a9d9151e028034ab46375f44fab39bfb459f91eb4a07c77e8da"
+            "hash": "0b27e19bb05e75ce5128d5992c71d7d3196b7ab2edfd8eee3bc7e014575ab679"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.17.0.