### PR TITLE
Scoop manifest update for auth0-cli version v1.17.1

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.17.0",
+    "version": "1.17.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "a843e40381e805b97cfb98b09f6c7400dd993811024040b7a1d35538bf7efde7"
+            "hash": "18709ccdea2e89755e6831601a86b101cd717a64480f152ef8fb04d7f6df9cd6"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.0/auth0-cli_1.17.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "0b27e19bb05e75ce5128d5992c71d7d3196b7ab2edfd8eee3bc7e014575ab679"
+            "hash": "d9220f6d4125c574f16581216042d912dd27993f50189fa69d62c75bfbeda09f"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.17.1.