### PR TITLE
Scoop manifest update for auth0-cli version v1.18.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.17.1",
+    "version": "1.18.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.18.0/auth0-cli_1.18.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "18709ccdea2e89755e6831601a86b101cd717a64480f152ef8fb04d7f6df9cd6"
+            "hash": "49377dd282e5a5cf3c78c21452a7c3f54ab189861d6643ba7c1d578b20b16200"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.17.1/auth0-cli_1.17.1_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.18.0/auth0-cli_1.18.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "d9220f6d4125c574f16581216042d912dd27993f50189fa69d62c75bfbeda09f"
+            "hash": "79d181268295e15267e19ab4c2a191db3e572f6dac06b7406af3ef1d362e8639"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.18.0.