### PR TITLE
Scoop manifest update for auth0-cli version v1.19.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.18.0",
+    "version": "1.19.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.18.0/auth0-cli_1.18.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.19.0/auth0-cli_1.19.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "49377dd282e5a5cf3c78c21452a7c3f54ab189861d6643ba7c1d578b20b16200"
+            "hash": "b6354240069823e4d7dbd9bcb8be6dd26ccbd729f48df9ae4ead80fa8a391b98"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.18.0/auth0-cli_1.18.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.19.0/auth0-cli_1.19.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "79d181268295e15267e19ab4c2a191db3e572f6dac06b7406af3ef1d362e8639"
+            "hash": "323178bc8bae9be5a12652cd38774578b93b2f6e454c9422e7f327a66bb7850f"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.19.0.