### PR TITLE
Scoop manifest update for auth0-cli version v1.20.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.19.0",
+    "version": "1.20.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.19.0/auth0-cli_1.19.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.0/auth0-cli_1.20.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "b6354240069823e4d7dbd9bcb8be6dd26ccbd729f48df9ae4ead80fa8a391b98"
+            "hash": "9c4f1dc6ab6455e5b2bd3c23e718054bf431c7c1347c64d2c70e97ab490592b9"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.19.0/auth0-cli_1.19.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.0/auth0-cli_1.20.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "323178bc8bae9be5a12652cd38774578b93b2f6e454c9422e7f327a66bb7850f"
+            "hash": "0d2dbc80780834a9e913458a1d69162c32c9967d47461126cb3619d045bf85c4"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.20.0.