### PR TITLE
Scoop manifest update for auth0-cli version v1.20.1

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.20.0",
+    "version": "1.20.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.0/auth0-cli_1.20.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.1/auth0-cli_1.20.1_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "9c4f1dc6ab6455e5b2bd3c23e718054bf431c7c1347c64d2c70e97ab490592b9"
+            "hash": "21afb1a2a3ee6682bcc9487a77772572c919502f5e909e9806e9a26fecb62f29"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.0/auth0-cli_1.20.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.1/auth0-cli_1.20.1_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "0d2dbc80780834a9e913458a1d69162c32c9967d47461126cb3619d045bf85c4"
+            "hash": "8f85555aee1439dfa9c77ca138e327b2ccb25b268a07ee383dd2c2dba2ec0f53"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.20.1.