### PR TITLE
Scoop manifest update for auth0-cli version v1.21.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.20.1",
+    "version": "1.21.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.1/auth0-cli_1.20.1_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.21.0/auth0-cli_1.21.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "21afb1a2a3ee6682bcc9487a77772572c919502f5e909e9806e9a26fecb62f29"
+            "hash": "217121e83a8113f082b3745ba6771d2d8c617cebabaa72bf54f428d6867c5714"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.20.1/auth0-cli_1.20.1_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.21.0/auth0-cli_1.21.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "8f85555aee1439dfa9c77ca138e327b2ccb25b268a07ee383dd2c2dba2ec0f53"
+            "hash": "caff7e5b876b05ee0fddc0857716a75c0655f518d681ba52dec6be4575d5eeed"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.21.0.