### PR TITLE
Scoop manifest update for auth0-cli version v1.27.2

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.27.1",
+    "version": "1.27.2",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.27.1/auth0-cli_1.27.1_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.27.2/auth0-cli_1.27.2_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "3fb549dbd5ad94b1d2b728bf843b582a955d176b4ebb5a06c0849e0c5bf01175"
+            "hash": "2abd95c71bd6c76e7fbd8103aed5f35e1ee4766b05869f75c1840ef99dd040ac"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.27.1/auth0-cli_1.27.1_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.27.2/auth0-cli_1.27.2_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "d5acfc066801ecb05179ea68314d38822d503729c9a252b9f042ff52100cd8f1"
+            "hash": "47842525690c50e77152f58e2a93e7209ebb4ebc08e922645cbab20646a60996"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.27.2.