### PR TITLE
Scoop manifest update for auth0-cli version v1.28.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.27.2",
+    "version": "1.28.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.27.2/auth0-cli_1.27.2_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.28.0/auth0-cli_1.28.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "2abd95c71bd6c76e7fbd8103aed5f35e1ee4766b05869f75c1840ef99dd040ac"
+            "hash": "3a218568855c34a8b17a1d9d811eacf95bc1bf0951c3b26797b68e652d48ced3"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.27.2/auth0-cli_1.27.2_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.28.0/auth0-cli_1.28.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "47842525690c50e77152f58e2a93e7209ebb4ebc08e922645cbab20646a60996"
+            "hash": "a11d8d85f05af1fe900efe4636dbda18309a6573bcc2d317915934d5b17a1ff6"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.28.0.