### PR TITLE
Scoop manifest update for auth0-cli version v1.30.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.29.0",
+    "version": "1.30.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.29.0/auth0-cli_1.29.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.30.0/auth0-cli_1.30.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "26821f83b4a10d88d53b9154bf698256c629bdc16298c56d78a580bb519272ae"
+            "hash": "893be5c44acf4abc8bbdbd452f7ac8ecefb98ebc6613d518ca95e91789a78c1d"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.29.0/auth0-cli_1.29.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.30.0/auth0-cli_1.30.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "b704f3fbdbd0dfaf1f0cc610cb07997ef6fc5296b68cb167de5674aa90756125"
+            "hash": "7f1dd5bdae8e2e388f746818fc625aa45e616f4585d3e384dfc92a93d616f508"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.30.0.