### PR TITLE
Scoop manifest update for auth0-cli version v1.31.0

### DIFF
--- a/auth0.json
+++ b/auth0.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.30.0",
+    "version": "1.31.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.30.0/auth0-cli_1.30.0_Windows_x86_64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.31.0/auth0-cli_1.31.0_Windows_x86_64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "893be5c44acf4abc8bbdbd452f7ac8ecefb98ebc6613d518ca95e91789a78c1d"
+            "hash": "8c051e8f8fe3d973958412569b5961eb2a6005ffd4813ea9f76ebe715f94623f"
         },
         "arm64": {
-            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.30.0/auth0-cli_1.30.0_Windows_arm64.zip",
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.31.0/auth0-cli_1.31.0_Windows_arm64.zip",
             "bin": [
                 "auth0.exe"
             ],
-            "hash": "7f1dd5bdae8e2e388f746818fc625aa45e616f4585d3e384dfc92a93d616f508"
+            "hash": "6e73a5dec146a918acac539d6d2b75d1e68093b50348a1df215616bc7c187d13"
         }
     },
     "homepage": "https://auth0.github.io/auth0-cli",


### PR DESCRIPTION
This PR updates the Scoop manifest for version v1.31.0.