### PR TITLE
Add beta manifest for Auth0 CLI version 1.33.0-beta.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,35 @@
 
 This repository contains the Scoop app manifest to install the [Auth0 CLI](https://github.com/auth0/auth0-cli).
 
-> Note: The CLI is currently in an experimental state and is not supported by Auth0. It has not had a complete security review, and we do not recommend using it to interact with production tenants.
-
 ### Installation
+
+First, add the bucket:
 
 ```sh
 $ scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+```
+
+#### Stable
+
+Install the latest stable release:
+
+```sh
 $ scoop install auth0
+```
+
+#### Beta
+
+A beta track is also available for previewing new features before they land in the stable release. Beta builds are pre-release and may be unstable — do not use them against production tenants.
+
+```sh
+$ scoop install auth0-beta
+```
+
+Both tracks provide the `auth0` command, so install one or the other — not both at the same time. To switch from stable to beta, uninstall first:
+
+```sh
+$ scoop uninstall auth0
+$ scoop install auth0-beta
 ```
 
 ## What is Auth0?

--- a/auth0-beta.json
+++ b/auth0-beta.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.33.0-beta.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.33.0-beta.0/auth0-cli_1.33.0-beta.0_Windows_x86_64.zip",
+            "bin": [
+                "auth0.exe"
+            ],
+            "hash": "667c3c59140836aa0f694110f008e5c8c34da18ee70014a333331625852a2eff"
+        },
+        "arm64": {
+            "url": "https://github.com/auth0/auth0-cli/releases/download/v1.33.0-beta.0/auth0-cli_1.33.0-beta.0_Windows_arm64.zip",
+            "bin": [
+                "auth0.exe"
+            ],
+            "hash": "cfd139373098ab300429d41d0245387dfbbde551b5f912ddb8a729b7095d743b"
+        }
+    },
+    "homepage": "https://auth0.github.io/auth0-cli",
+    "license": "MIT",
+    "description": "Build, manage and test your Auth0 integrations from the command line",
+    "post_install": [
+        "Write-Host 'Thanks for installing the Auth0 CLI'"
+    ]
+}


### PR DESCRIPTION
This pull request updates the documentation and adds support for installing a beta version of the Auth0 CLI using Scoop. The main changes clarify installation instructions and introduce a new manifest for the beta release, allowing users to preview new features before they are released in the stable version.

**Documentation improvements:**

* Expanded installation instructions in `README.md` to clearly separate stable and beta installation tracks, including usage notes and guidance on switching between them.

**Beta release support:**

* Added a new manifest file `auth0-beta.json` to enable installation of the Auth0 CLI beta version via Scoop, including architecture-specific binaries and hashes.